### PR TITLE
Nps 559 glightbox postinstall

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+unsafe-perm = true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.0.11
+- Fixed permission problem when running npm postinstall scripts inside container
+
 # 1.0.10
 - GLightbox is added via npm now
 


### PR DESCRIPTION
Fixes the permission issue with npm postinstall scripts inside containers